### PR TITLE
ci: bump Swift to 6.2 in the lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-24.04-arm
-    container: swift:6.1
+    container: swift:6.2
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
       - run: swift format lint -rsp .

--- a/.swift-format
+++ b/.swift-format
@@ -21,11 +21,7 @@
     ]
   },
   "prioritizeKeepingFunctionOutputTogether" : true,
-  "reflowMultilineStringLiterals" : {
-    "never" : {
-
-    }
-  },
+  "reflowMultilineStringLiterals" : "never",
   "respectsExistingLineBreaks" : true,
   "rules" : {
     "AllPublicDeclarationsHaveDocumentation" : true,


### PR DESCRIPTION
Also, I updated .swift-format so that it matches to the default in Swift 6.2.